### PR TITLE
text/plain media type on HelloController

### DIFF
--- a/test-suite/src/test/groovy/io/micronaut/docs/server/intro/HelloController.java
+++ b/test-suite/src/test/groovy/io/micronaut/docs/server/intro/HelloController.java
@@ -26,7 +26,7 @@ import io.micronaut.http.annotation.*;
 // tag::class[]
 @Controller("/hello") // <1>
 public class HelloController {
-    @Get // <2>
+    @Get(produces = MediaType.TEXT_PLAIN) // <2>
     public String index() {
         return "Hello World"; // <3>
     }


### PR DESCRIPTION
Default Micronaut configuration produces application/json. So if you run the example in a browser (rather than curl), you can get an error page about invalid JSON (like on Firefox 63).